### PR TITLE
fix: use and emit custom classes

### DIFF
--- a/src/cli/core/FileContentGenerator.ts
+++ b/src/cli/core/FileContentGenerator.ts
@@ -81,14 +81,14 @@ export class FileContentGenerator {
     return (
       'export type TTailwindString = "TAILWIND_STRING"\n' +
       '\n' +
-      'export type TKey = TClasses | TTailwindString\n' +
+      'export type TKey = TClasses | TTailwindStringIMPORTED_T_CUSTOM_CLASSES_KEY\n' +
       '\n' +
       'export type TArg =\n' +
       '| TClasses\n' +
       '| null\n' +
       '| undefined\n' +
       '| {[key in TKey]?: boolean}\n' +
-      '| TTailwindString\n' +
+      '| TTailwindString\nIMPORTED_T_CUSTOM_CLASSES_ARG' +
       '\n' +
       'export type TTailwind = (...args: TArg[]) => TTailwindString\n' +
       '\n' +

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,12 +24,12 @@ commander
   .option('-x, --extra <extra>', 'Name or relative path of the file with the custom extra types')
 
   // Define the action of the CLI
-  .action(({input, output, classesFile: extra}: {[key: string]: string | void}) => {
+  .action(({input, output, extra}: {[key: string]: string | void}) => {
     const isConfigFileFound: boolean = fs.existsSync('./tailwind.config.js');
     // If the config file is found or provided explicitly by the user...
     if (isConfigFileFound || !!input) {
       // Generate the types and write them to a file on disk
-      void new GeneratedFileWriter({
+      return new GeneratedFileWriter({
         configFilename: isConfigFileFound ? 'tailwind.config.js' : input,
         outputFilename: output,
         customClassesFilename: extra,
@@ -61,7 +61,7 @@ commander
         ])
         .then((answers: TInquirerAnswers) => {
           // Get the answers and use them to create the file with generated types
-          void new GeneratedFileWriter({
+          return new GeneratedFileWriter({
             configFilename: answers.configFilename,
             outputFilename: answers.outputFilename,
             customClassesFilename: answers.customClassesFilename,


### PR DESCRIPTION
Hello,

I noticed the custom classes feature was not working when using command line arguments. I've fixed the command line arguments parsing, error checking, and emit.