### PR TITLE
fix(flexbox): add 'justify-evenly'

### DIFF
--- a/src/cli/lib/non-configurable/flexbox.ts
+++ b/src/cli/lib/non-configurable/flexbox.ts
@@ -46,6 +46,7 @@ const justifyContent = [
   'justify-end',
   'justify-between',
   'justify-around',
+  'justify-evenly',
 ];
 
 const justifyItems = [


### PR DESCRIPTION
## Summary

First, thanks for creating this awesome package!

This PR is intended to add `justify-evenly`, which is mentioned in [Tailwind CSS](https://tailwindcss.com/docs/justify-content).

Thanks for the code review!