### PR TITLE
fix: support darkMode manual 'class' option

### DIFF
--- a/src/cli/core/TailwindConfigParser.ts
+++ b/src/cli/core/TailwindConfigParser.ts
@@ -121,7 +121,7 @@ export class TailwindConfigParser {
 
     // get responsive variants
     const [mediaBreakpoints] = this.getThemeProperty('screens');
-    if (this.getDarkMode() == 'media') mediaBreakpoints.push('dark');
+    if (this.getDarkMode() == 'media' || this.getDarkMode() == 'class') mediaBreakpoints.push('dark');
 
     mediaBreakpoints.map((breakpoint: string) => {
       if (!variants.includes(breakpoint)) {


### PR DESCRIPTION
This seems to fix the issue regarding tailwindcss-classnames not supporting darkMode when darkMode is set to 'class'