### PR TITLE
refactor: switch to @colors/colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "dist"
   ],
   "dependencies": {
+    "@colors/colors": "^1.5.0",
     "clsx": "^1.1.1",
-    "colors": "1.4.0",
     "commander": "^7.0.0",
     "inquirer": "^8.1.1",
     "lodash": "^4.17.15",

--- a/src/cli/core/GeneratedFileWriter.ts
+++ b/src/cli/core/GeneratedFileWriter.ts
@@ -3,7 +3,7 @@
 import {promises as fs} from 'fs';
 import vm from 'vm';
 import path from 'path';
-import colors from 'colors';
+import colors from '@colors/colors';
 import {ClassnamesGenerator} from './ClassnamesGenerator';
 import {TailwindConfigParser} from './TailwindConfigParser';
 import {FileContentGenerator} from './FileContentGenerator';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,7 @@
 
 import commander from 'commander';
 import inquirer from 'inquirer';
-import colors from 'colors';
+import colors from '@colors/colors';
 import fs from 'fs';
 
 import {GeneratedFileWriter} from './core/GeneratedFileWriter';

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,6 +310,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@colors/colors@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@commitlint/cli@^12.1.4":
   version "12.1.4"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-12.1.4.tgz#af4d9dd3c0122c7b39a61fa1cd2abbad0422dbe0"
@@ -1761,11 +1766,6 @@ colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
-
-colors@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
Using the `colors` dependency is an operational risk, as it is no longer maintained.
This PR switches to a maintained version (https://github.com/DABH/colors.js)